### PR TITLE
Volume creation breaks if peer creation fails

### DIFF
--- a/lib/puppet/provider/gluster.rb
+++ b/lib/puppet/provider/gluster.rb
@@ -60,17 +60,6 @@ class Puppet::Provider::Gluster < Puppet::Provider
     parse_peer_status(gluster_cmd('peer', 'status'))
   end
 
-  def self.peers_present(required_peers)
-    peers = all_peers
-    missing_peers = required_peers - peers
-    if (required_peers - all_peers).empty?
-      true
-    else
-      debug("Missing required peers: #{missing_peers.join(', ')}")
-      false
-    end
-  end
-
   # Volume information
 
   def self.parse_volume_info(doc)

--- a/lib/puppet/provider/gluster.rb
+++ b/lib/puppet/provider/gluster.rb
@@ -29,7 +29,7 @@ module GlusterCmdHelpers
   def gluster_cmd(*args)
     output = gluster('--xml', '--mode=script', *args)
     doc = REXML::Document.new(output)
-    if opRet = cli_text(doc, 'opRet') != '0'
+    if (opRet = cli_text(doc, 'opRet')) != '0'
       raise GlusterCmdError.new(
         opRet, cli_text(doc, 'opErrno'), cli_text(doc, 'opErrstr'))
     end

--- a/lib/puppet/provider/gluster.rb
+++ b/lib/puppet/provider/gluster.rb
@@ -1,11 +1,17 @@
-module XPathHelpers
+class GlusterCmdError < Puppet::ExecutionFailure
+  attr_reader :opRet, :opErrno, :opErrstr
+  def initialize(opRet, opErrno, opErrstr)
+    @opRet = opRet
+    @opErrno = opErrno
+    @opErrstr = opErrstr
+    super("Execution failed (#{opRet}) #{opErrno}: #{opErrstr}")
+  end
+end
+
+module GlusterCmdHelpers
   def value_if_text(node)
-    case node.node_type
-    when :text
-      node.value
-    else
-      node
-    end
+    return node.value if node.node_type == :text
+    node
   end
 
   def xpath_match(node, query)
@@ -15,7 +21,22 @@ module XPathHelpers
   def xpath_first(node, query)
     value_if_text(REXML::XPath.first(node, query))
   end
+
+  def cli_text(doc, path)
+    xpath_first(doc, "/cliOutput/#{path}/text()")
+  end
+
+  def gluster_cmd(*args)
+    output = gluster('--xml', '--mode=script', *args)
+    doc = REXML::Document.new(output)
+    if opRet = cli_text(doc, 'opRet') != '0'
+      raise GlusterCmdError.new(
+        opRet, cli_text(doc, 'opErrno'), cli_text(doc, 'opErrstr'))
+    end
+    doc
+  end
 end
+
 
 class Puppet::Provider::Gluster < Puppet::Provider
 
@@ -26,22 +47,13 @@ class Puppet::Provider::Gluster < Puppet::Provider
   # end
 
   # We want these to be both class and instance methods.
-  extend XPathHelpers
-  include XPathHelpers
+  extend GlusterCmdHelpers
+  include GlusterCmdHelpers
 
   # Peer information
 
-  def self.parse_peer_status(output)
-    doc = REXML::Document.new(output)
+  def self.parse_peer_status(doc)
     xpath_match(doc, '/cliOutput/peerStatus/peer/hostname/text()')
-  end
-
-  def self.gluster_cmd(*args)
-    gluster('--xml', '--mode=script', *args)
-  end
-
-  def gluster_cmd(*args)
-    gluster('--xml', '--mode=script', *args)
   end
 
   def self.all_peers
@@ -61,8 +73,7 @@ class Puppet::Provider::Gluster < Puppet::Provider
 
   # Volume information
 
-  def self.parse_volume_info(output)
-    doc = REXML::Document.new(output)
+  def self.parse_volume_info(doc)
     xpath_match(doc, '/cliOutput/volInfo/volumes/volume').map do |vol|
       extract_volume_info(vol)
     end
@@ -102,8 +113,7 @@ class Puppet::Provider::Gluster < Puppet::Provider
   end
 
   def self.all_volumes
-    output = gluster_cmd('volume', 'info', 'all')
-    parse_volume_info(output)
+    parse_volume_info(gluster_cmd('volume', 'info', 'all'))
   end
 
   def get_volume_info(name)

--- a/lib/puppet/provider/gluster_peer/gluster_peer.rb
+++ b/lib/puppet/provider/gluster_peer/gluster_peer.rb
@@ -30,26 +30,20 @@ Puppet::Type.type(:gluster_peer).provide(
     @property_hash[:ensure] == :present
   end
 
-  def handle_peer_probe(output)
-    doc = REXML::Document.new(output)
-    if xpath_first(doc, '/cliOutput/opRet/text()') == '0'
-      # Success, we're done.
-      @property_hash[:ensure] = :present
-    else
-      # TODO: Check that this works on older glusterfs as well.
-      if xpath_first(doc, '/cliOutput/opErrno/text()') == '107'
-        # This indicates an unreachable peer.
-        warning(
-          "Peer '#{resource[:peer]}' is unreachable, not actually creating.")
-      else
-        raise Puppet::ExecutionFailure, xpath_first(
-          doc, '/cliOutput/opErrstr/text()')
-      end
-    end
-  end
-
   def create
-    handle_peer_probe(gluster_cmd('peer', 'probe', resource[:peer]))
+    gluster_cmd('peer', 'probe', resource[:peer])
+    # If there's no exception, we're done.
+    @property_hash[:ensure] = :present
+  rescue GlusterCmdError => e
+    if e.opErrno == '107'
+      # FIXME: Is this opErrno check narrow enough? Some other commands have
+      # very different errors sharing an errno value.
+      warning([
+          "Peer '#{resource[:peer]}' unreachable, not actually creating.",
+          "(#{e.opErrstr})"].join(' '))
+    else
+      raise e
+    end
   end
 
   def destroy

--- a/lib/puppet/provider/gluster_volume/gluster_volume.rb
+++ b/lib/puppet/provider/gluster_volume/gluster_volume.rb
@@ -25,6 +25,13 @@ Puppet::Type.type(:gluster_volume).provide(
     end
   end
 
+  def missing_peers
+    peers = self.class.all_peers
+    [:hostname, :fqdn, :ipaddress].each { |f| peers << Facter.value(f) }
+    required_peers = resource[:bricks].map { |brick| brick.split(':')[0] }
+    required_peers - peers
+  end
+
   def create_volume
     info("Creating volume #{resource[:name]} (#{@property_hash[:ensure]})")
     args = []

--- a/lib/puppet/provider/gluster_volume/gluster_volume.rb
+++ b/lib/puppet/provider/gluster_volume/gluster_volume.rb
@@ -26,9 +26,13 @@ Puppet::Type.type(:gluster_volume).provide(
   end
 
   def missing_peers
+    # First get the hostnames of all the remote peers we know about.
     peers = self.class.all_peers
+    # Then add our own addresses so we know the local machine isn't missing.
     [:hostname, :fqdn, :ipaddress].each { |f| peers << Facter.value(f) }
-    required_peers = resource[:bricks].map { |brick| brick.split(':')[0] }
+    # Extract and dedupe peer addresses from the volume bricks.
+    required_peers = resource[:bricks].map { |brick| brick.split(':')[0] }.uniq
+    # Return a list of all brick peers we don't know about.
     required_peers - peers
   end
 

--- a/lib/puppet/type/gluster_peer.rb
+++ b/lib/puppet/type/gluster_peer.rb
@@ -33,8 +33,8 @@ Puppet::Type.newtype(:gluster_peer) do
     defaultto []
 
     munge do |val|
-      facts = ['fqdn', 'hostname', 'ipaddress', 'ipaddress_lo']
-      Array(val) + facts.map { |n| Facter[n] }.compact.map { |f| f.value }
+      facts = [:fqdn, :hostname, :ipaddress, :ipaddress_lo]
+      Array(val) + facts.map { |f| Facter.value(f) }.compact
     end
   end
 

--- a/lib/puppet/type/gluster_volume.rb
+++ b/lib/puppet/type/gluster_volume.rb
@@ -33,6 +33,23 @@ Puppet::Type.newtype(:gluster_volume) do
     def retrieve
       provider.get(:ensure)
     end
+
+    # We want to ignore volumes with missing peers here.
+    def property_matches?(current, desired)
+      if current != desired
+        missing_peers = provider.missing_peers
+        unless missing_peers.empty?
+          info([
+              "Ignoring '#{resource[:name]}' (pretending it's #{desired})",
+              'because the following peers are missing:',
+              missing_peers.join(', '),
+            ].join(' '))
+          return true
+        end
+      end
+      # We're not pretending, so invoke the original method.
+      super
+    end
   end
 
   # TODO: More params, etc.

--- a/spec/helpers/fake_gluster.rb
+++ b/spec/helpers/fake_gluster.rb
@@ -14,7 +14,7 @@ module GlusterXML
   def make_cli_err(ops={})
     ops[:opRet] ||= -1
     ops[:opErrno] ||= 0
-    ops[:errSt] ||= 'error'
+    ops[:opErrstr] ||= 'error'
     make_cli_root(ops[:opRet], ops[:opErrno], ops[:opErrstr])
   end
 

--- a/spec/helpers/log_matcher.rb
+++ b/spec/helpers/log_matcher.rb
@@ -1,0 +1,24 @@
+RSpec::Matchers.define :have_logged do |*expected|
+  def call_and_collect(&block)
+    logs = []
+    destination = Puppet::Test::LogCollector.new(logs)
+    old_level = Puppet::Util::Log.level
+    Puppet::Util::Log.level = :debug
+    begin
+      Puppet::Util::Log.with_destination(destination, &block)
+    ensure
+      Puppet::Util::Log.level = old_level
+    end
+    logs
+  end
+
+  match do |block|
+    logs = call_and_collect(&block)
+    expected.all? do |val, level=nil|
+      actual = logs.select { |log| level.nil? or log.level == level }
+      actual.any? { |log| values_match?(val, log.message) }
+    end
+  end
+
+  supports_block_expectations
+end

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -218,10 +218,8 @@ describe 'integration', :integration => true do
           }
           MANIFEST
           expect(trx.any_failed?).to be_nil
-          expect(trx.changed?.map(&:to_s).sort).to eq([
-              'Gluster_peer[gfs1.local]',
-              'Gluster_volume[vol1]',
-            ])
+          expect(trx.changed?.map(&:to_s)).to contain_exactly(
+            'Gluster_peer[gfs1.local]', 'Gluster_volume[vol1]')
           expect(@fake_gluster.volume_names).to eq(['vol1'])
           expect(@fake_gluster.get_volume('vol1').started?).to eq(true)
         end
@@ -235,15 +233,13 @@ describe 'integration', :integration => true do
           }
           MANIFEST
           expect(trx.any_failed?).to be_nil
-          expect(trx.changed?.map(&:to_s).sort).to eq([
-              'Gluster_peer[gfs1.local]',
-              'Gluster_volume[vol1]',
-            ])
+          expect(trx.changed?.map(&:to_s)).to contain_exactly(
+            'Gluster_peer[gfs1.local]', 'Gluster_volume[vol1]')
           expect(@fake_gluster.volume_names).to eq(['vol1'])
           vol = @fake_gluster.get_volume('vol1')
           expect(vol.started?).to eq(true)
-          expect(vol.bricks.map { |b| b[:name] }.sort).to eq(
-            ["#{Facter.value(:fqdn)}:/b1/v1", 'gfs1.local:/b1/v1'].sort)
+          expect(vol.bricks.map { |b| b[:name] }).to contain_exactly(
+            "#{Facter.value(:fqdn)}:/b1/v1", 'gfs1.local:/b1/v1')
           expect(vol[:replica]).to eq(1)
         end
 
@@ -257,15 +253,13 @@ describe 'integration', :integration => true do
           }
           MANIFEST
           expect(trx.any_failed?).to be_nil
-          expect(trx.changed?.map(&:to_s).sort).to eq([
-              'Gluster_peer[gfs1.local]',
-              'Gluster_volume[vol1]',
-            ])
+          expect(trx.changed?.map(&:to_s)).to contain_exactly(
+            'Gluster_peer[gfs1.local]', 'Gluster_volume[vol1]')
           expect(@fake_gluster.volume_names).to eq(['vol1'])
           vol = @fake_gluster.get_volume('vol1')
           expect(vol.started?).to eq(true)
-          expect(vol.bricks.map { |b| b[:name] }.sort).to eq(
-            ["#{Facter.value(:fqdn)}:/b1/v1", 'gfs1.local:/b1/v1'].sort)
+          expect(vol.bricks.map { |b| b[:name] }).to contain_exactly(
+            "#{Facter.value(:fqdn)}:/b1/v1", 'gfs1.local:/b1/v1')
           expect(vol[:replica]).to eq('2')
         end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -17,3 +17,4 @@ end
 # These helpers are useful to have everywhere.
 require 'helpers/fake_facts'
 require 'helpers/fake_gluster'
+require 'helpers/log_matcher'

--- a/spec/unit/helpers/log_matcher_spec.rb
+++ b/spec/unit/helpers/log_matcher_spec.rb
@@ -1,0 +1,82 @@
+require 'rspec/matchers/fail_matchers'
+
+RSpec.configure do |config|
+  config.include RSpec::Matchers::FailMatchers
+end
+
+class Logger
+  include Puppet::Util::Logging
+end
+
+describe 'log_matcher' do
+  before :each do
+    @log = Logger.new
+  end
+
+  it 'finds a message by string' do
+    expect { @log.notice('foo!') }.to have_logged('foo!')
+    expect { @log.debug('foo!') }.to have_logged(['foo!', :debug])
+    expect { @log.warning('foo!') }.to have_logged(['foo!', :warning])
+    expect {
+      expect { @log.info('foo!') }.to have_logged('foo')
+    }.to fail_with('no logged messages match "foo"')
+  end
+
+  it 'finds a message by regex' do
+    expect { @log.notice('Pity the fool!') }.to have_logged(/foo/)
+    expect { @log.debug('Pity the fool!') }.to have_logged([/foo/, :debug])
+    expect { @log.warning('Pity the fool!') }.to have_logged([/foo/, :warning])
+    expect {
+      expect { @log.info('Pity the foal!') }.to have_logged(/foo/)
+    }.to fail_with('no logged messages match /foo/')
+  end
+
+  it 'finds a message with an arbitrary matcher' do
+    expect { @log.notice('Bad thing') }.to have_logged(start_with('Bad'))
+    expect { @log.debug('Bad thing') }.to have_logged([end_with('ng'), :debug])
+  end
+
+  it 'finds multiple messages' do
+    expect {
+      @log.notice('Millenium hand and shrimp')
+      @log.info('Bad thing')
+      @log.debug('Pity the fool!')
+    }.to have_logged(
+      [/foo/, :debug],
+      'Millenium hand and shrimp',
+      [start_with('Bad'), :info],
+      end_with('ng'))
+  end
+
+  it 'does not find a message logged at the wrong level' do
+    expect {
+      expect { @log.info('Pity the fool!') }.to have_logged([/foo/, :warning])
+    }.to fail_with('no logged warning messages match /foo/')
+    expect {
+      expect { @log.info('Pity the fool!') }.to have_logged([/foo/, :debug])
+    }.to fail_with('no logged debug messages match /foo/')
+  end
+
+  it 'emits a useful message on failure' do
+    expect {
+      expect {}.to have_logged(/foo/)
+    }.to fail_with('no logged messages match /foo/')
+    expect {
+      expect {}.to have_logged([/foo/, :debug])
+    }.to fail_with('no logged debug messages match /foo/')
+  end
+
+  it 'reports the first expected message it fails to find' do
+    expect {
+      expect {
+        @log.notice('Millenium hand and shrimp')
+        @log.info('Good thing')
+        @log.debug('Pity the fool!')
+      }.to have_logged(
+        [/foo/, :debug],
+        'Millenium hand and shrimp',
+        [/^Bad/, :info],
+        end_with('gn'))
+    }.to fail_with('no logged info messages match /^Bad/')
+  end
+end

--- a/spec/unit/provider/gluster_peer_spec.rb
+++ b/spec/unit/provider/gluster_peer_spec.rb
@@ -167,9 +167,7 @@ describe peer_type.provider(:gluster_peer), :unit => true do
 
         it 'should fail on an unexpected error' do
           @fake_gluster.set_error(-1, 2, 'A bad thing happened.')
-          expect {
-            @unreachable_peer.create
-          }.to raise_error(Puppet::ExecutionFailure)
+          expect { @unreachable_peer.create }.to raise_error(GlusterCmdError)
         end
       end
 

--- a/spec/unit/provider/gluster_peer_spec.rb
+++ b/spec/unit/provider/gluster_peer_spec.rb
@@ -152,7 +152,8 @@ describe peer_type.provider(:gluster_peer), :unit => true do
           @fake_gluster.peer_unreachable(
             'unreachable.local', 'Probe returned with unknown errno 107')
           expect(@fake_gluster.peer_hosts).to eq([])
-          @unreachable_peer.create
+          expect { @unreachable_peer.create }.to have_logged(
+            [/not actually creating.*unknown errno 107/, :warning])
           expect(@fake_gluster.peer_hosts).to eq([])
         end
 
@@ -161,7 +162,8 @@ describe peer_type.provider(:gluster_peer), :unit => true do
             'unreachable.local',
             'Probe returned with Transport endpoint is not connected')
           expect(@fake_gluster.peer_hosts).to eq([])
-          @unreachable_peer.create
+          expect { @unreachable_peer.create }.to have_logged(
+            [/not actually creating.*Transport endpoint is not/, :warning])
           expect(@fake_gluster.peer_hosts).to eq([])
         end
 

--- a/spec/unit/provider/gluster_volume_spec.rb
+++ b/spec/unit/provider/gluster_volume_spec.rb
@@ -202,6 +202,18 @@ describe volume_type.provider(:gluster_volume), :unit => true do
         end
       end
 
+      describe 'edge cases' do
+        before :each do
+          @new_volume = described_class.new(
+            @volume_type.new(:name => 'vol1', :bricks => ['gfs1.local:/b/v']))
+        end
+
+        it 'should fail on an unexpected error' do
+          @fake_gluster.set_error(-1, 2, 'A bad thing happened.')
+          expect { @new_volume.create }.to raise_error(GlusterCmdError)
+        end
+      end
+
     end
   end
 end

--- a/spec/unit/provider/gluster_volume_spec.rb
+++ b/spec/unit/provider/gluster_volume_spec.rb
@@ -23,7 +23,7 @@ describe volume_type.provider(:gluster_volume), :unit => true do
       end
 
       describe 'class methods' do
-        [:instances, :prefetch, :peers_present, :all_volumes].each do |method|
+        [:instances, :prefetch, :all_volumes].each do |method|
           it "should have method named #{method}" do
             expect(described_class).to respond_to method
           end
@@ -43,35 +43,68 @@ describe volume_type.provider(:gluster_volume), :unit => true do
         end
 
         describe 'a new volume' do
-          before :each do
-            @new_volume = described_class.new(
-              @volume_type.new(:name => 'vol1', :replica => 2, :bricks => [
-                  'gfs1.local:/b1/vol1',
-                  'gfs2.local:/b1/vol1',
-                ]))
+
+          describe 'with one local brick' do
+            before :each do
+              @new_volume = described_class.new(
+                @volume_type.new(:name => 'vol1', :replica => 2, :bricks => [
+                    "#{Facter.value(:fqdn)}:/b1/vol1",
+                  ]))
+            end
+
+            it 'should not exist' do
+              expect(@new_volume.get(:ensure)).to eq(:absent)
+            end
+
+            it 'should be created and started' do
+              expect(@fake_gluster.volume_names).to eq([])
+              @new_volume.create
+              expect(@fake_gluster.volume_names).to eq(['vol1'])
+              expect(@new_volume.get(:ensure)).to eq(:present)
+              # TODO: Check various properties.
+            end
+
+            it 'should be created without being started' do
+              expect(@fake_gluster.volume_names).to eq([])
+              @new_volume.ensure_stopped
+              expect(@fake_gluster.volume_names).to eq(['vol1'])
+              expect(@new_volume.get(:ensure)).to eq(:stopped)
+              # TODO: Check various properties.
+            end
           end
 
-          it 'should not exist' do
-            expect(@new_volume.get(:ensure)).to eq(:absent)
+          describe 'with two remote bricks' do
+            before :each do
+              @new_volume = described_class.new(
+                @volume_type.new(:name => 'vol1', :replica => 2, :bricks => [
+                    'gfs1.local:/b1/vol1',
+                    'gfs2.local:/b1/vol1',
+                  ]))
+            end
+
+            it 'should not exist' do
+              expect(@new_volume.get(:ensure)).to eq(:absent)
+            end
+
+            it 'should be created and started' do
+              @fake_gluster.add_peers('gfs1.local', 'gfs2.local')
+              expect(@fake_gluster.volume_names).to eq([])
+              @new_volume.create
+              expect(@fake_gluster.volume_names).to eq(['vol1'])
+              expect(@new_volume.get(:ensure)).to eq(:present)
+              # TODO: Check various properties.
+            end
+
+            it 'should be created without being started' do
+              @fake_gluster.add_peers('gfs1.local', 'gfs2.local')
+              expect(@fake_gluster.volume_names).to eq([])
+              @new_volume.ensure_stopped
+              expect(@fake_gluster.volume_names).to eq(['vol1'])
+              expect(@new_volume.get(:ensure)).to eq(:stopped)
+              # TODO: Check various properties.
+            end
           end
 
-          it 'should be created and started' do
-            @fake_gluster.add_peers('gfs1.local', 'gfs2.local')
-            expect(@fake_gluster.volume_names).to eq([])
-            @new_volume.create
-            expect(@fake_gluster.volume_names).to eq(['vol1'])
-            expect(@new_volume.get(:ensure)).to eq(:present)
-            # TODO: Check various properties.
-          end
-
-          it 'should be created without being started' do
-            @fake_gluster.add_peers('gfs1.local', 'gfs2.local')
-            expect(@fake_gluster.volume_names).to eq([])
-            @new_volume.ensure_stopped
-            expect(@fake_gluster.volume_names).to eq(['vol1'])
-            expect(@new_volume.get(:ensure)).to eq(:stopped)
-            # TODO: Check various properties.
-          end
         end
       end
 
@@ -167,9 +200,7 @@ describe volume_type.provider(:gluster_volume), :unit => true do
             expect(@volume.get(:ensure)).to eq(:stopped)
             # TODO: Check various properties.
           end
-
         end
-
       end
 
       context 'with two volumes' do
@@ -199,6 +230,34 @@ describe volume_type.provider(:gluster_volume), :unit => true do
           expect(res_providers(res)).to eq([nil, nil, nil])
           described_class.prefetch(res_hash(res))
           expect(res_providers(res)).to eq(['vol1', 'vol2', nil])
+        end
+      end
+
+      describe 'missing_peers' do
+        it 'should return a list of missing peers' do
+          @fake_gluster.add_peers('gfs2.local', 'gfs4.local')
+          expect(
+            described_class.new(@volume_type.new(:name => 'vol1', :bricks => [
+                  'gfs1.local:/b1/v1',
+                  'gfs2.local:/b1/v1',
+                  'gfs3.local:/b1/v1',
+                ])).missing_peers
+          ).to contain_exactly('gfs1.local', 'gfs3.local')
+          expect(
+            described_class.new(@volume_type.new(:name => 'vol1', :bricks => [
+                  'gfs2.local:/b1/v1',
+                  'gfs4.local:/b1/v1',
+                ])).missing_peers
+          ).to be_empty
+        end
+
+        it 'should treat the current host as present' do
+          expect(
+            described_class.new(@volume_type.new(:name => 'vol1', :bricks => [
+                  "#{Facter.value(:fqdn)}:/b1/vol1",
+                  'gfs1.local:/b1/v1',
+                ])).missing_peers
+          ).to contain_exactly('gfs1.local')
         end
       end
 

--- a/spec/unit/provider/gluster_volume_spec.rb
+++ b/spec/unit/provider/gluster_volume_spec.rb
@@ -259,6 +259,18 @@ describe volume_type.provider(:gluster_volume), :unit => true do
                 ])).missing_peers
           ).to contain_exactly('gfs1.local')
         end
+
+        it 'should deduplicate peers with multiple bricks' do
+          @fake_gluster.add_peers('gfs2.local')
+          expect(
+            described_class.new(@volume_type.new(:name => 'vol1', :bricks => [
+                  'gfs1.local:/b1/v1',
+                  'gfs2.local:/b1/v1',
+                  'gfs1.local:/b2/v1',
+                  'gfs2.local:/b2/v1',
+                ])).missing_peers
+          ).to contain_exactly('gfs1.local')
+        end
       end
 
       describe 'edge cases' do


### PR DESCRIPTION
This is a problem during cluster setup where the first puppet run probably won't be able to create peers properly.

The solution is to check for that condition and log an appropriate warning instead of failing.