### PR TITLE
Better handling of local peer addresses

### DIFF
--- a/lib/puppet/provider/gluster_volume/gluster_volume.rb
+++ b/lib/puppet/provider/gluster_volume/gluster_volume.rb
@@ -26,10 +26,9 @@ Puppet::Type.type(:gluster_volume).provide(
   end
 
   def missing_peers
-    # First get the hostnames of all the remote peers we know about.
-    peers = self.class.all_peers
-    # Then add our own addresses so we know the local machine isn't missing.
-    [:hostname, :fqdn, :ipaddress].each { |f| peers << Facter.value(f) }
+    # We know about a peer if the cluster knows about it or if it's a local
+    # alias.
+    peers = self.class.all_peers + resource[:local_peer_aliases]
     # Extract and dedupe peer addresses from the volume bricks.
     required_peers = resource[:bricks].map { |brick| brick.split(':')[0] }.uniq
     # Return a list of all brick peers we don't know about.

--- a/lib/puppet/type/gluster_peer.rb
+++ b/lib/puppet/type/gluster_peer.rb
@@ -35,7 +35,7 @@ Puppet::Type.newtype(:gluster_peer) do
     defaultto []
 
     munge do |val|
-      facts = [:fqdn, :hostname, :ipaddress, :ipaddress_lo]
+      facts = [:fqdn, :hostname, :ipaddress]
       Array(val) + facts.map { |f| Facter.value(f) }.compact
     end
   end

--- a/lib/puppet/type/gluster_peer.rb
+++ b/lib/puppet/type/gluster_peer.rb
@@ -27,9 +27,11 @@ Puppet::Type.newtype(:gluster_peer) do
 
   newparam(:peer, :namevar => true)
 
-  newparam(:ignore_peers, :array_matching => :all) do
-    desc("Peer addresses to ignore. " +
-         "This should include anything that resolves to the current host.")
+  newparam(:local_peer_aliases, :array_matching => :all) do
+    desc([
+        'Other names for the current host.',
+        'Anything included here will be ignored when checking peers.',
+      ].join(' '))
     defaultto []
 
     munge do |val|
@@ -39,10 +41,10 @@ Puppet::Type.newtype(:gluster_peer) do
   end
 
   def ignore?
-    value(:ignore_peers).include? value(:peer)
+    value(:local_peer_aliases).include? value(:peer)
   end
 
   autorequire(:service) do
-    "glusterfs-server"
+    'glusterfs-server'
   end
 end

--- a/lib/puppet/type/gluster_volume.rb
+++ b/lib/puppet/type/gluster_volume.rb
@@ -80,6 +80,19 @@ Puppet::Type.newtype(:gluster_volume) do
     munge { |val| Array(val) }
   end
 
+  newparam(:local_peer_aliases, :array_matching => :all) do
+    desc([
+        'Other names for the current host.',
+        'Anything included here will be ignored when checking peers.',
+      ].join(' '))
+    defaultto []
+
+    munge do |val|
+      facts = [:fqdn, :hostname, :ipaddress]
+      Array(val) + facts.map { |f| Facter.value(f) }.compact
+    end
+  end
+
   autorequire(:service) do
     "glusterfs-server"
   end

--- a/spec/helpers/fake_gluster.rb
+++ b/spec/helpers/fake_gluster.rb
@@ -190,12 +190,17 @@ class FakeGluster
     @volumes = []
     @error = nil
     @unreachable_peers = {}
+    @local_addresses = [Facter.value(:fqdn)]
   end
 
   # Manipulate and inspect state.
 
   def set_error(opRet, opErrno=-1, opErrstr='')
     @error = { :opRet => opRet, :opErrstr => opErrno, :opErrstr => opErrstr }
+  end
+
+  def add_local_alias(address)
+    @local_addresses << address
   end
 
   def add_peer(hostname, peer_hash={})
@@ -315,7 +320,7 @@ class FakeGluster
     params[:status] = 0
     params[:statusStr] = 'Created'
     volume = FakeVolume.new(name, bricks, params)
-    all_peers = peer_hosts + [Facter.value(:fqdn)]
+    all_peers = peer_hosts + @local_addresses
     volume.peers.each do |peer|
       return format_doc(make_cli_err(
           :opErrno => 30800,

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -288,6 +288,34 @@ describe 'integration', :integration => true do
           expect(@fake_gluster.get_volume('vol1').started?).to eq(true)
         end
 
+        it 'should not add a volume with missing peers' do
+          expect(@fake_gluster.volume_names).to eq([])
+          trx = apply_node_manifest(<<-'MANIFEST')
+          gluster_volume { 'vol1':
+            bricks => ["${fqdn}:/b1/v1", 'gfs1.local:/b1/v1'],
+          }
+          MANIFEST
+          expect(trx.any_failed?).to be_nil
+          expect(trx.changed?.map(&:to_s)).to eq([])
+          expect(@fake_gluster.volume_names).to eq([])
+        end
+
+        it 'should add a volume with a local peer alias' do
+          @fake_gluster.add_local_alias('alias.local')
+          expect(@fake_gluster.peer_hosts).to eq([])
+          expect(@fake_gluster.volume_names).to eq([])
+          trx = apply_node_manifest(<<-'MANIFEST')
+          gluster_volume { 'vol1':
+            bricks => ['alias.local:/b1/v1'],
+            local_peer_aliases => ['alias.local'],
+          }
+          MANIFEST
+          expect(trx.any_failed?).to be_nil
+          expect(trx.changed?.map(&:to_s)).to eq(['Gluster_volume[vol1]'])
+          expect(@fake_gluster.volume_names).to eq(['vol1'])
+          expect(@fake_gluster.get_volume('vol1').started?).to eq(true)
+        end
+
         it 'should start a stopped volume' do
           @fake_gluster.add_volume(
             'vol1', ["#{Facter.value(:fqdn)}:/b1/v1"],

--- a/spec/integration/integration_spec.rb
+++ b/spec/integration/integration_spec.rb
@@ -62,11 +62,11 @@ describe 'integration', :integration => true do
           expect(@fake_gluster.peer_hosts).to eq(['gfs1.local', 'gfs2.local'])
         end
 
-        it 'should ignore inappropriate peers' do
+        it 'should ignore local peer addresses' do
           expect(@fake_gluster.peer_hosts).to eq([])
           trx = apply_node_manifest(<<-'MANIFEST')
-          gluster_peer { ["$ipaddress", 'gfs1.local', 'badpeer.local']:
-            ignore_peers => ['badpeer.local'],
+          gluster_peer { ["$ipaddress", 'gfs1.local', 'hostalias.local']:
+            local_peer_aliases => ['hostalias.local'],
           }
           MANIFEST
           expect(trx.any_failed?).to be_nil

--- a/spec/unit/provider/.#gluster_volume_spec.rb
+++ b/spec/unit/provider/.#gluster_volume_spec.rb
@@ -1,1 +1,0 @@
-jerith@kilrah.1033

--- a/spec/unit/provider/.#gluster_volume_spec.rb
+++ b/spec/unit/provider/.#gluster_volume_spec.rb
@@ -1,0 +1,1 @@
+jerith@kilrah.1033

--- a/spec/unit/provider/gluster_volume_spec.rb
+++ b/spec/unit/provider/gluster_volume_spec.rb
@@ -260,6 +260,19 @@ describe volume_type.provider(:gluster_volume), :unit => true do
           ).to contain_exactly('gfs1.local')
         end
 
+        it 'should treat any local peer aliases as present' do
+          expect(
+            described_class.new(@volume_type.new(
+                :name => 'vol1',
+                :local_peer_aliases => ['alias1.local', 'alias2.local'],
+                :bricks => [
+                  'gfs1.local:/b1/v1',
+                  'alias1.local:/b1/v1',
+                  'alias2.local:/b1/v1',
+                ])).missing_peers
+          ).to contain_exactly('gfs1.local')
+        end
+
         it 'should deduplicate peers with multiple bricks' do
           @fake_gluster.add_peers('gfs2.local')
           expect(

--- a/spec/unit/type/gluster_peer_spec.rb
+++ b/spec/unit/type/gluster_peer_spec.rb
@@ -57,28 +57,28 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
           # really hard to get rid of the facts.
 
           it "should include default values" do
-            default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
+            default = get_facts(:fqdn, :hostname, :ipaddress)
             expect(
               described_class.new(:peer => 'foo')
             ).to satisfy { |v| v[:local_peer_aliases] == default }
           end
 
           it "should accept a single string" do
-            default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
+            default = get_facts(:fqdn, :hostname, :ipaddress)
             expect(described_class.new(
                 :peer => 'foo', :local_peer_aliases => 'foo')
             ).to satisfy { |v| v[:local_peer_aliases] == ['foo'] + default }
           end
 
           it "should accept an array containing a single string" do
-            default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
+            default = get_facts(:fqdn, :hostname, :ipaddress)
             expect(described_class.new(
                 :peer => 'foo', :local_peer_aliases => ['foo'])
             ).to satisfy { |v| v[:local_peer_aliases] == ['foo'] + default }
           end
 
           it "should accept an array containing many strings" do
-            default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
+            default = get_facts(:fqdn, :hostname, :ipaddress)
             expect(described_class.new(
                 :peer => 'foo', :local_peer_aliases => ['a', 'b'])
             ).to satisfy { |v| v[:local_peer_aliases] == ['a', 'b'] + default }
@@ -112,10 +112,10 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
             expect(rtype.parameter(:ensure).insync? :present).to eq(true)
           end
 
-          it 'should ignore localhost' do
+          it 'should ignore the local host' do
             # We ignore peers by always pretending they're in sync.
             rtype = described_class.new(
-              :peer => '127.0.0.1',
+              :peer => Facter.value(:fqdn),
               :ensure => :present)
             expect(rtype.parameter(:ensure).insync? :absent).to eq(true)
             expect(rtype.parameter(:ensure).insync? :present).to eq(true)

--- a/spec/unit/type/gluster_peer_spec.rb
+++ b/spec/unit/type/gluster_peer_spec.rb
@@ -8,12 +8,12 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
       end
 
       describe 'when validating attributes' do
-        [ :peer, :local_peer_aliases ].each do |param|
+        [:peer, :local_peer_aliases].each do |param|
           it "should have a #{param} parameter" do
             expect(described_class.attrtype(param)).to eq(:param)
           end
         end
-        [ :ensure ].each do |prop|
+        [:ensure].each do |prop|
           it "should have a #{prop} parameter" do
             expect(described_class.attrtype(prop)).to eq(:property)
           end

--- a/spec/unit/type/gluster_peer_spec.rb
+++ b/spec/unit/type/gluster_peer_spec.rb
@@ -7,11 +7,6 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
         stub_facts(facts)
       end
 
-      # This uses `define_method` so that `facts` is in scope.
-      define_method(:get_facts) do |*names|
-        names.map { |name| facts[name] }
-      end
-
       describe 'when validating attributes' do
         [ :peer, :local_peer_aliases ].each do |param|
           it "should have a #{param} parameter" do
@@ -35,20 +30,20 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
         describe 'peer' do
           it "should accept a hostname" do
             expect(
-              described_class.new(:peer => 'gfs1')
-            ).to satisfy { |v| v[:peer] == 'gfs1' }
+              described_class.new(:peer => 'gfs1')[:peer]
+            ).to eq('gfs1')
           end
 
           it "should accept a fully qualified domain" do
             expect(
-              described_class.new(:peer => 'gfs2.example.com')
-            ).to satisfy { |v| v[:peer] == 'gfs2.example.com' }
+              described_class.new(:peer => 'gfs2.example.com')[:peer]
+            ).to eq('gfs2.example.com')
           end
 
           it "should accept an IP" do
             expect(
-              described_class.new(:peer => '1.2.3.4')
-            ).to satisfy { |v| v[:peer] == '1.2.3.4' }
+              described_class.new(:peer => '1.2.3.4')[:peer]
+            ).to eq('1.2.3.4')
           end
         end
 
@@ -56,32 +51,34 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
           # FIXME: This should test the missing fact handling, but it seems
           # really hard to get rid of the facts.
 
+          default_aliases = facts.values_at(:fqdn, :hostname, :ipaddress)
+
+          def lpa_of_new(args={})
+            described_class.new(args)[:local_peer_aliases]
+          end
+
           it "should include default values" do
-            default = get_facts(:fqdn, :hostname, :ipaddress)
             expect(
-              described_class.new(:peer => 'foo')
-            ).to satisfy { |v| v[:local_peer_aliases] == default }
+              lpa_of_new(:peer => 'foo')
+            ).to contain_exactly(*default_aliases)
           end
 
           it "should accept a single string" do
-            default = get_facts(:fqdn, :hostname, :ipaddress)
-            expect(described_class.new(
-                :peer => 'foo', :local_peer_aliases => 'foo')
-            ).to satisfy { |v| v[:local_peer_aliases] == ['foo'] + default }
+            expect(
+              lpa_of_new(:peer => 'foo', :local_peer_aliases => 'foo')
+            ).to contain_exactly('foo', *default_aliases)
           end
 
           it "should accept an array containing a single string" do
-            default = get_facts(:fqdn, :hostname, :ipaddress)
-            expect(described_class.new(
-                :peer => 'foo', :local_peer_aliases => ['foo'])
-            ).to satisfy { |v| v[:local_peer_aliases] == ['foo'] + default }
+            expect(
+              lpa_of_new(:peer => 'foo', :local_peer_aliases => ['foo'])
+            ).to contain_exactly('foo', *default_aliases)
           end
 
           it "should accept an array containing many strings" do
-            default = get_facts(:fqdn, :hostname, :ipaddress)
-            expect(described_class.new(
-                :peer => 'foo', :local_peer_aliases => ['a', 'b'])
-            ).to satisfy { |v| v[:local_peer_aliases] == ['a', 'b'] + default }
+            expect(
+              lpa_of_new(:peer => 'foo', :local_peer_aliases => ['a', 'b'])
+            ).to contain_exactly('a', 'b', *default_aliases)
           end
         end
 

--- a/spec/unit/type/gluster_peer_spec.rb
+++ b/spec/unit/type/gluster_peer_spec.rb
@@ -13,7 +13,7 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
       end
 
       describe 'when validating attributes' do
-        [ :peer, :ignore_peers ].each do |param|
+        [ :peer, :local_peer_aliases ].each do |param|
           it "should have a #{param} parameter" do
             expect(described_class.attrtype(param)).to eq(:param)
           end
@@ -52,7 +52,7 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
           end
         end
 
-        describe 'ignore_peers' do
+        describe 'local_peer_aliases' do
           # FIXME: This should test the missing fact handling, but it seems
           # really hard to get rid of the facts.
 
@@ -60,28 +60,28 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
             default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
             expect(
               described_class.new(:peer => 'foo')
-            ).to satisfy { |v| v[:ignore_peers] == default }
+            ).to satisfy { |v| v[:local_peer_aliases] == default }
           end
 
           it "should accept a single string" do
             default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
-            expect(
-              described_class.new(:peer => 'foo', :ignore_peers => 'foo')
-            ).to satisfy { |v| v[:ignore_peers] == ['foo'] + default }
+            expect(described_class.new(
+                :peer => 'foo', :local_peer_aliases => 'foo')
+            ).to satisfy { |v| v[:local_peer_aliases] == ['foo'] + default }
           end
 
           it "should accept an array containing a single string" do
             default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
-            expect(
-              described_class.new(:peer => 'foo', :ignore_peers => ['foo'])
-            ).to satisfy { |v| v[:ignore_peers] == ['foo'] + default }
+            expect(described_class.new(
+                :peer => 'foo', :local_peer_aliases => ['foo'])
+            ).to satisfy { |v| v[:local_peer_aliases] == ['foo'] + default }
           end
 
           it "should accept an array containing many strings" do
             default = get_facts(:fqdn, :hostname, :ipaddress, :ipaddress_lo)
-            expect(
-              described_class.new(:peer => 'foo', :ignore_peers => ['a', 'b'])
-            ).to satisfy { |v| v[:ignore_peers] == ['a', 'b'] + default }
+            expect(described_class.new(
+                :peer => 'foo', :local_peer_aliases => ['a', 'b'])
+            ).to satisfy { |v| v[:local_peer_aliases] == ['a', 'b'] + default }
           end
         end
 
@@ -103,7 +103,7 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
           end
         end
 
-        describe 'ignoring peers' do
+        describe 'local peer aliases' do
           it 'should not ignore arbitrary peers' do
             rtype = described_class.new(
               :peer => 'peer.example.com',
@@ -121,12 +121,12 @@ describe Puppet::Type.type(:gluster_peer), :unit => true do
             expect(rtype.parameter(:ensure).insync? :present).to eq(true)
           end
 
-          it 'should ignore ignored peers' do
+          it 'should ignore local peer aliases' do
             # We ignore peers by always pretending they're in sync.
             rtype = described_class.new(
               :peer => 'peer.example.com',
               :ensure => :present,
-              :ignore_peers => ['peer.example.com'])
+              :local_peer_aliases => ['peer.example.com'])
             expect(rtype.parameter(:ensure).insync? :absent).to eq(true)
             expect(rtype.parameter(:ensure).insync? :present).to eq(true)
           end

--- a/spec/unit/type/gluster_volume_spec.rb
+++ b/spec/unit/type/gluster_volume_spec.rb
@@ -8,13 +8,13 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
       end
 
       describe 'when validating attributes' do
-        [ :name, :force, :replica, :bricks ].each do |param|
+        [:name, :force, :replica, :bricks, :local_peer_aliases].each do |param|
           it "should have a #{param} parameter" do
             expect(described_class.attrtype(param)).to eq(:param)
           end
         end
 
-        [ :ensure ].each do |prop|
+        [:ensure].each do |prop|
           it "should have a #{prop} parameter" do
             expect(described_class.attrtype(prop)).to eq(:property)
           end
@@ -101,6 +101,41 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
             expect(described_class.new(
                 :name => 'data1', :bricks => ['p1:b1', 'p2:b1'])[:bricks]
             ).to eq(['p1:b1', 'p2:b1'])
+          end
+        end
+
+        describe 'local_peer_aliases' do
+          # FIXME: This should test the missing fact handling, but it seems
+          # really hard to get rid of the facts.
+
+          default_aliases = facts.values_at(:fqdn, :hostname, :ipaddress)
+
+          def lpa_of_new(args={})
+            described_class.new(args)[:local_peer_aliases]
+          end
+
+          it "should include default values" do
+            expect(
+              lpa_of_new(:name => 'foo')
+            ).to contain_exactly(*default_aliases)
+          end
+
+          it "should accept a single string" do
+            expect(
+              lpa_of_new(:name => 'foo', :local_peer_aliases => 'foo')
+            ).to contain_exactly('foo', *default_aliases)
+          end
+
+          it "should accept an array containing a single string" do
+            expect(
+              lpa_of_new(:name => 'foo', :local_peer_aliases => ['foo'])
+            ).to contain_exactly('foo', *default_aliases)
+          end
+
+          it "should accept an array containing many strings" do
+            expect(
+              lpa_of_new(:name => 'foo', :local_peer_aliases => ['a', 'b'])
+            ).to contain_exactly('a', 'b', *default_aliases)
           end
         end
 

--- a/spec/unit/type/gluster_volume_spec.rb
+++ b/spec/unit/type/gluster_volume_spec.rb
@@ -239,6 +239,13 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
             expect { @res.property(:ensure).sync }.to_not raise_error
           end
 
+          it 'should create if no peers are missing' do
+            @res[:bricks] = [1, 2, 3].map { |n| "gfs#{n}.local:/b1/v1" }
+            allow(@prov).to receive(:missing_peers).and_return([])
+            expect(@res.property(:ensure).insync? :absent).to eq(false)
+            expect(@res.property(:ensure).insync? :present).to eq(true)
+          end
+
           it 'should not create if a peer is missing' do
             @res[:bricks] = [1, 2, 3].map { |n| "gfs#{n}.local:/b1/v1" }
             allow(@prov).to receive(:missing_peers).and_return(
@@ -252,7 +259,7 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
               [/gfs1\.local/, :info],
               [/gfs3\.local/, :info],
             )
-            expect(@res.property(:ensure).insync? :absent).to eq(true)
+            expect(@res.property(:ensure).insync? :present).to eq(true)
           end
         end
 

--- a/spec/unit/type/gluster_volume_spec.rb
+++ b/spec/unit/type/gluster_volume_spec.rb
@@ -30,9 +30,7 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
       describe 'when validating attribute values' do
         describe 'name' do
           it 'should accept a string' do
-            expect(
-              described_class.new(:name => 'data1')
-            ).to satisfy { |v| v[:name] == 'data1' }
+            expect(described_class.new(:name => 'data1')[:name]).to eq('data1')
           end
         end
 
@@ -54,21 +52,19 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
 
         describe 'replica' do
           it 'should accept an empty value' do
-            expect(
-              described_class.new(:name => 'data1')
-            ).to satisfy { |v| v[:replica].nil? }
+            expect(described_class.new(:name => 'data1')[:replica]).to be_nil
           end
 
           it 'should accept an integer >= 2' do
             expect(
-              described_class.new(:name => 'data1', :replica => 2)
-            ).to satisfy { |v| v[:replica] == 2 }
+              described_class.new(:name => 'data1', :replica => 2)[:replica]
+            ).to eq(2)
             expect(
-              described_class.new(:name => 'data1', :replica => '2')
-            ).to satisfy { |v| v[:replica] == 2 }
+              described_class.new(:name => 'data1', :replica => '2')[:replica]
+            ).to eq(2)
             expect(
-              described_class.new(:name => 'data1', :replica => '17')
-            ).to satisfy { |v| v[:replica] == 17 }
+              described_class.new(:name => 'data1', :replica => '17')[:replica]
+            ).to eq(17)
           end
 
           it 'should not accept an integer < 2' do
@@ -86,28 +82,25 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
 
         describe 'bricks' do
           it 'should default to an empty array' do
-            expect(
-              described_class.new(:name => 'data1')
-            ).to satisfy { |v| v[:bricks] == [] }
+            expect(described_class.new(:name => 'data1')[:bricks]).to eq([])
           end
 
           it 'should accept a single string' do
-            expect(
-              described_class.new(:name => 'data1', :bricks => 'p1:b1')
-            ).to satisfy { |v| v[:bricks] == ['p1:b1'] }
+            expect(described_class.new(
+                :name => 'data1', :bricks => 'p1:b1')[:bricks]
+            ).to eq(['p1:b1'])
           end
 
           it 'should accept an array containing a single string' do
-            expect(
-              described_class.new(:name => 'data1', :bricks => ['p1:b1'])
-            ).to satisfy { |v| v[:bricks] == ['p1:b1'] }
+            expect(described_class.new(
+                :name => 'data1', :bricks => ['p1:b1'])[:bricks]
+            ).to eq(['p1:b1'])
           end
 
           it 'should accept an array containing many strings' do
-            expect(
-              described_class.new(
-              :name => 'data1', :bricks => ['p1:b1', 'p2:b1'])
-            ).to satisfy { |v| v[:bricks] == ['p1:b1', 'p2:b1'] }
+            expect(described_class.new(
+                :name => 'data1', :bricks => ['p1:b1', 'p2:b1'])[:bricks]
+            ).to eq(['p1:b1', 'p2:b1'])
           end
         end
 


### PR DESCRIPTION
We currently have `ignore_peers` in the peer resource and some hardcoded fact names in the volume resource. We should use a common `local_peer_addresses` parameter for both.