### PR TITLE
Autorequire brick dirs for local peers

### DIFF
--- a/lib/puppet/type/gluster_volume.rb
+++ b/lib/puppet/type/gluster_volume.rb
@@ -98,4 +98,12 @@ Puppet::Type.newtype(:gluster_volume) do
   autorequire(:gluster_peer) do
     value(:bricks).map { |brick| brick.split(":")[0] }.uniq
   end
+  autorequire(:file) do
+    files = []
+    value(:bricks).each do |brick|
+      peer, dir = brick.split(":")
+      files << dir if value(:local_peer_aliases).include? peer
+    end
+    files.uniq
+  end
 end

--- a/lib/puppet/type/gluster_volume.rb
+++ b/lib/puppet/type/gluster_volume.rb
@@ -105,5 +105,9 @@ Puppet::Type.newtype(:gluster_volume) do
   autorequire(:service) { 'glusterfs-server' }
   autorequire(:package) { 'glusterfs-server' }
   autorequire(:gluster_peer) { split_bricks.map(&:first).uniq }
-  autorequire(:file) { local_bricks.map { |peer, dir| dir }.uniq }
+  autorequire(:file) do
+    # The last segment of the path is created by gluster, so we require the
+    # directory one level up from that.
+    local_bricks.map { |peer, dir| File.dirname(dir) }.uniq
+  end
 end

--- a/spec/unit/type/gluster_volume_spec.rb
+++ b/spec/unit/type/gluster_volume_spec.rb
@@ -192,6 +192,14 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
               autoreq_vol('p1:/b', 'p2:/b', 'p3:/b')
             ).to contain_exactly('Gluster_peer[p1]', 'Gluster_peer[p2]')
           end
+
+          it 'should require any local brick dirs that are declared' do
+            @cat.create_resource(:file, :title => '/b1', :ensure => 'directory')
+            @cat.create_resource(:file, :title => '/b2', :ensure => 'directory')
+            expect(
+              autoreq_vol("#{Facter.value(:fqdn)}:/b1", 'p2:/b2', 'p3:/b3')
+            ).to eq(['File[/b1]'])
+          end
         end
 
         describe 'ensure behaviour' do

--- a/spec/unit/type/gluster_volume_spec.rb
+++ b/spec/unit/type/gluster_volume_spec.rb
@@ -196,8 +196,8 @@ describe Puppet::Type.type(:gluster_volume), :unit => true do
           it 'should require any local brick dirs that are declared' do
             @cat.create_resource(:file, :title => '/b1', :ensure => 'directory')
             @cat.create_resource(:file, :title => '/b2', :ensure => 'directory')
-            expect(
-              autoreq_vol("#{Facter.value(:fqdn)}:/b1", 'p2:/b2', 'p3:/b3')
+            expect(autoreq_vol(
+                "#{Facter.value(:fqdn)}:/b1/v1", 'p2:/b2/v1', 'p3:/b3/v1')
             ).to eq(['File[/b1]'])
           end
         end


### PR DESCRIPTION
A volume autorequires all remote peers, but it doesn't autorequire brick directories on the local peer.